### PR TITLE
Add `solc` service and wrapper binary

### DIFF
--- a/bin/solc
+++ b/bin/solc
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+source ${ETH}/bin/utils.sh
+echo "1"
+
+SERVICE="solc"
+
+
+main() {
+    local opts=${@:1}
+
+    local name=$(echo "solc-$(get-container-dapp-path)" | tr '/' '-')
+
+    local extra_run_opts="--rm --name ${name}"
+
+    local run_opts=$( get-run-opts ${extra_run_opts} )
+
+    local pkgs=
+    if [ -d "./installed_contracts" ]; then
+        pkgs=$(cd installed_contracts && ls -d *)
+    fi
+
+    local pkg_dir=
+    local include_args=
+    for pkg in $pkgs
+    do
+        pkg_dir="$(get-container-dapp-path)/installed_contracts/${pkg}/contracts"
+        include_args="${include_args} ${pkg}=${pkg_dir}"
+    done
+
+    run-docker-compose \
+        run ${run_opts} \
+        ${SERVICE} \
+        solc ${include_args} ${opts}
+}
+
+main "$@"

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -43,6 +43,12 @@ services:
     ports:
       - "80"
 
+  solc:
+    image: ethereum/solc:stable
+    tty: true
+    volumes:
+      - "${ETH}/dapps:/var/dapps"
+
   truffle:
     stdin_open: true
     tty: true


### PR DESCRIPTION
The wrapper binary is set up to (initially) link contracts installed in `installed_contracts` in the dapp container directories, using the `pkg=pkg_dir` syntax for `solc`.

Current limitation: it looks specifically for `installed_contracts/{pkg_dir}/contracts`, to find Solidity files.