### PR TITLE
Support dapps via truffle

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+source ${ETH}/bin/utils.sh
+
+SERVICE="truffle"
+
+
+main() {
+    local cmd=$1
+    local opts
+    if [ "${cmd}" == "run" ]
+    then
+        cmd="${cmd} $2"
+        opts=${@:3}
+    else
+        opts=${@:2}
+    fi
+
+    local name=$(echo "npm-${cmd// /-}-$(get-container-dapp-path)" | tr '/' '-')
+    local extra_run_opts="--rm --name ${name}"
+
+    if [ "${cmd}" == "run dev" ]
+    then
+        local port_map="9999:9999"  # opens ephemeral port
+        extra_run_opts="${extra_run_opts} -p ${port_map}"
+    fi
+
+    local run_opts=$( get-run-opts ${extra_run_opts} )
+
+    run-docker-compose \
+        run ${run_opts} \
+        ${SERVICE} \
+        npm ${cmd} ${opts}
+}
+
+main "$@"

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -53,6 +53,8 @@ services:
     stdin_open: true
     tty: true
     build: truffle
+    ports:
+      - "9999"
     networks:
       - ethereum-dev
       - ethereum-testnet
@@ -71,12 +73,14 @@ services:
       - "${ETH}/containers/nginx/nginx.conf:/etc/nginx/nginx.conf"
     networks:
       - ethereum-testnet
+      - ethereum-dev
     ports:
       - "80:80"
       - "8080:8080"
       - "8545:8545"
     links:
       - parity-testnet
+      - testrpc
     entrypoint: >
       /bin/bash -c "nginx -g 'daemon off;'"
 

--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -8,6 +8,13 @@ events {
 }
 
 http {
+    log_format upstreamlog '[$time_local] $remote_addr - $remote_user - $server_name  to: $upstream_addr: $request upstream_response_time $upstream_response_time msec $msec request_time $request_time';
+
+    upstream testrpc {
+        least_conn;
+        server testrpc:8545 weight=10 max_fails=3 fail_timeout=30s;
+    }
+
     upstream parity-testnet-jsonrpc {
         least_conn;
         server parity-testnet:8545 weight=10 max_fails=3 fail_timeout=30s;
@@ -23,22 +30,22 @@ http {
         server parity-testnet:8080 weight=10 max_fails=3 fail_timeout=30s;
     }
 
-# If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
-# scheme used to connect to this server
+    # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+    # scheme used to connect to this server
     map $http_x_forwarded_proto $proxy_x_forwarded_proto {
       default $http_x_forwarded_proto;
       ''      $scheme;
     }
 
-# If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
-# server port the client connected to
+    # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
+    # server port the client connected to
     map $http_x_forwarded_port $proxy_x_forwarded_port {
       default $http_x_forwarded_port;
       ''      $server_port;
     }
 
-# If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
-# Connection header that may have been passed to this server
+    # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+    # Connection header that may have been passed to this server
     map $http_upgrade $proxy_connection {
       default upgrade;
       '' close;
@@ -63,7 +70,6 @@ http {
             proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
             proxy_read_timeout 86400;
         }
-
     }
 
     server {
@@ -97,6 +103,27 @@ http {
             proxy_buffering off;
             proxy_set_header Host '0.0.0.0:8180';
             proxy_set_header Origin '0.0.0.0:8180';
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $proxy_connection;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+            proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+        }
+    }
+
+    server {
+        listen 8545;
+
+        access_log /var/log/nginx/access.log upstreamlog;
+        server_name testrpc.ethereum;
+
+        location / {
+            proxy_pass http://testrpc;
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_set_header Host 'testrpc:8545';
+            proxy_set_header Origin 'testrpc:8545';
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $proxy_connection;
             proxy_set_header X-Real-IP $remote_addr;

--- a/containers/testrpc/Dockerfile
+++ b/containers/testrpc/Dockerfile
@@ -1,4 +1,4 @@
 FROM node:6.9.1
 RUN npm install -g ethereumjs-testrpc@3.0.3
 EXPOSE 8545
-CMD testrpc
+CMD testrpc -h 0.0.0.0 -p 8545


### PR DESCRIPTION
- Expecting `npm run dev` to open server on port 9999
- Exposing `testrpc.ethereum` as nginx host for browser dapp to access RPC