### PR TITLE
Remove host dependency on Python

### DIFF
--- a/bin/activate.sh
+++ b/bin/activate.sh
@@ -1,9 +1,10 @@
-ETH=$( echo ${BASH_SOURCE-$_} | xargs dirname | xargs dirname )   # bootstrap relative ETH
+# bootstrap relative ETH
+ETH=$( echo ${BASH_SOURCE-$_} | xargs dirname | xargs dirname )
 
 if [ "${ETHACTIVE-0}" -gt "0" ]
 then
     # first deactivate to clear anything out
-    . ${ETH}/bin/deactivate.sh
+    source ${ETH}/bin/deactivate.sh
 fi
 
 activate() {

--- a/bin/deactivate.sh
+++ b/bin/deactivate.sh
@@ -16,4 +16,3 @@ unset deactivate
 unset ETHACTIVE
 echo "gone!"
 popd >/dev/null
-

--- a/bin/os.path.sh
+++ b/bin/os.path.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Some useful path functions. Modelled after Python.
+#
+# License: MIT Open Source
+# Copyright (c) 2016 Joe Linoff
+#
+
+# Normalize a path.
+# Similar to Python's os.path.normpath()
+function os.path.normpath() {
+    local Path="$*"
+    local Clean=$(sed -e 's@//@/@g' \
+                      -e 's@/[^/]*/\.\./@/@' \
+                      -e 's@/[^/]*/\.\./@/@' \
+                      -e 's@/[^/]*/\.\./@/@' \
+                      -e 's@/[^/]*/\.\./@/@' \
+                      -e 's@/[^/]*/\.\.$@/@' \
+                      -e 's@/[^/]*/\.\.$@/@' \
+                      -e 's@^\./@@' \
+                      <<< "$Path")
+    echo "$Clean"
+}
+
+# Absolute path.
+# Similar to Python's os.path.abspath()
+function os.path.abspath() {
+    local Path="$*"
+    local AbsPath=$(os.path.normpath "$Path")
+    if [[ ! "$AbsPath" =~ ^/ ]] ; then
+        AbsPath="$(pwd)/$AbsPath"
+    fi
+    echo "$AbsPath"
+}
+
+# Relative path.
+# Similar to Python's os.path.relpath()
+function os.path.relpath() {
+    local Path="$*"
+    local RelPath=$(os.path.normpath "$Path")
+    local PwdPath=$(pwd)
+    local RelPathLen=${#RelPath}
+    local PwdPathLen=${#PwdPath}
+    local Done=0
+    if (( ${#RelPath} == PwdPathLen )) ; then
+        if [[ "$RelPath" == "$PwdPath" ]] ; then
+            RelPath="."
+            Done=1
+        fi
+    elif (( ${#RelPath} > PwdPathLen )) ; then
+        if [[ "${RelPath:0:$PwdPathLen}" == "$PwdPath" ]] ; then
+            RelPath="${RelPath:$PwdPathLen}"
+            if [[ "$RelPath" =~ ^/ ]] ; then
+                RelPath="${RelPath:1}"
+            fi
+            Done=1
+        fi
+    else
+        # Check for the case of:
+        #   RelPath = /a/b/c
+        #   PwdPath = /a/b/c/d/e
+        #   Result = ../..
+        if [[ "${PwdPath:0:$RelPathLen}" == "$RelPath" ]] ; then
+            local TmpPath="${PwdPath:$RelPathLen}"
+            NumDirs=$(grep -o '/' <<< "$TmpPath" | wc -l)
+            RelPath='..'
+            for((i=1; i<NumDirs; i++)) ; do
+                RelPath="${RelPath}/.."
+            done
+            Done=1
+        fi
+    fi
+
+    # Handle the special case of an absolute path.
+    if (( Done == 0 )) && [[ "$RelPath" =~ ^/ ]] ; then
+        NumDirs=$(grep -o '/' <<< "$PwdPath" | wc -l)
+        local Prefix='..'
+        for((i=1; i<NumDirs; i++)) ; do
+            Prefix="${Prefix}/.."
+        done
+        RelPath="${Prefix}${RelPath}"
+    fi
+    echo "$RelPath"
+}
+
+# Test the path functions.
+function os.path.test() {
+    Patterns=(
+        '/a/b/c/d'
+        '/a/b/c//d'
+        '/a/b//c//d'
+        '/a/b/c/..'
+        '/a/b/c/../d'
+        '/a/b/c/../../d'
+        '/a/b/../c/../d'
+        'a/b/c/d'
+        './a/b/c'
+        $(cd $(dirname -- $0) ; pwd)
+        $(cd $(dirname -- $(cd $(dirname -- $0) ; pwd)) ; pwd)
+        $(cd $(dirname -- $(cd $(dirname -- $(cd $(dirname -- $0) ; pwd)) ; pwd)) ; pwd)
+    )
+    for Pattern in "${Patterns[@]}" ; do
+        printf '%-40s -> ' "$Pattern"
+
+        Clean=$(os.path.normpath "$Pattern")
+        printf '%-40s -> ' "$Clean"
+
+        AbsPath=$(os.path.abspath "$Pattern")
+        printf '%-40s -> ' "$AbsPath"
+
+        RelPath=$(os.path.relpath "$Pattern")
+        printf '%s' "$RelPath"
+
+        printf '\n'
+    done
+}
+
+if [[ "$(basename $0)" == "$(basename $BASH_SOURCE)" ]] ; then
+    os.path.test
+fi

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -2,19 +2,32 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+env_bin=$( echo ${BASH_SOURCE-$_} | xargs dirname )
+. ${env_bin}/os.path.sh
+
 get-relpath() {
-    python -c 'import os.path, sys;\
-        print os.path.relpath(sys.argv[1],sys.argv[2]).replace(":","").replace("\\\\", "/")' "$1" "${2-$PWD}"
+    local path=$1
+    local start=${2-$PWD}
+    local pop=
+
+    if [[ "$start" != "$PWD" ]]; then
+      pushd $2 >/dev/null
+      pop=1
+    fi
+
+    os.path.relpath $start
+
+    if [ -n "$pop" ]; then
+      popd >/dev/null
+    fi
 }
 
 get-normpath() {
-    python -c 'import os.path, sys;\
-  print os.path.normpath(sys.argv[1])' "${1-$PWD}"
+    os.path.normpath "${1-$PWD}"
 }
 
 get-abspath() {
-    python -c 'import os.path, sys;\
-  print os.path.abspath(sys.argv[1])' "${1-$PWD}"
+    os.path.abspath "${1-$PWD}"
 }
 
 get-real-eth-home() {


### PR DESCRIPTION
Instead of using Python's `os.path.relpath`, `os.path.normpath`, etc., use Bash implementations from https://gist.github.com/jlinoff/cc76f5848af83f15cdbe